### PR TITLE
feat: optimize getting colors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.11"
 Pillow = "*"
-vacuum-map-parser-base = "0.1.2"
+vacuum-map-parser-base = "0.1.3"
 
 [tool.poetry.dev-dependencies]
 black = "*"


### PR DESCRIPTION
Depends on https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-base/pull/6

before:
![image](https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock/assets/20257911/5c6e4ca0-f5e0-47bc-9ad2-1dae63bde78d)

after:
![image](https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roborock/assets/20257911/58e68b63-76c0-4efa-94b8-c67d6b99679c)

Running 10 times each time recreating the parser on a smallish map on my local machine.

I think I could get some pretty significant time improvements by using numba, but i wasn't sure if that is something you would want and I'm not sure if it is worth the time of getting everything to be numba compatable in the parse function.