### PR TITLE
Support removed map

### DIFF
--- a/src/vacuum_map_parser_roborock/image_parser.py
+++ b/src/vacuum_map_parser_roborock/image_parser.py
@@ -24,7 +24,7 @@ class RoborockImageParser:
         self._image_config = image_config
 
     def parse(
-        self, raw_data: bytes, width: int, height: int, carpet_map: set[int] | None
+        self, raw_data: bytes, width: int, height: int, carpet_map: set[int] | None, removed_map: set[int] | None = None
     ) -> tuple[ImageType | None, dict[int, tuple[int, int, int, int]]]:
         rooms = {}
         scale = self._image_config.scale
@@ -47,7 +47,9 @@ class RoborockImageParser:
                 pixel_type = raw_data[idx]
                 x = img_x
                 y = trimmed_height - img_y - 1
-                if carpet_map is not None and idx in carpet_map and (x + y) % 2:
+                if removed_map is not None and idx in removed_map:
+                    pixels[x, y] = cached_colors[SupportedColor.MAP_OUTSIDE]
+                elif carpet_map is not None and idx in carpet_map and (x + y) % 2:
                     pixels[x, y] = cached_colors[SupportedColor.CARPETS]
                 elif pixel_type == RoborockImageParser.MAP_OUTSIDE:
                     pixels[x, y] = cached_colors[SupportedColor.MAP_OUTSIDE]

--- a/src/vacuum_map_parser_roborock/map_data_parser.py
+++ b/src/vacuum_map_parser_roborock/map_data_parser.py
@@ -48,11 +48,18 @@ class RoborockBlockType(Enum):
     IGNORED_OBSTACLES = 14
     OBSTACLES_WITH_PHOTO = 15
     IGNORED_OBSTACLES_WITH_PHOTO = 16
-    CARPET_MAP = 17
+    CARPET_MAP = 17 # Keep for backward compatibility
+    SUBMAP = 17
     MOP_PATH = 18
     NO_CARPET_AREAS = 19
     DIGEST = 1024
 
+class RoborockSubmapType(Enum):
+    """Roborock map block type."""
+
+    CARPET = 1
+    REMOVED_BORDER = 8
+    REMOVED_AREA = 16
 
 class RoborockMapDataParser(MapDataParser):
     """Roborock map parser."""
@@ -157,10 +164,11 @@ class RoborockMapDataParser(MapDataParser):
                     # only the map_data.path points where points_mask == 1 are in mop_path
                     if map_data.path is not None:
                         map_data.mop_path = RoborockMapDataParser._parse_mop_path(map_data.path, points_mask)
-                case RoborockBlockType.CARPET_MAP.value:
+                case RoborockBlockType.SUBMAP.value:
                     data = RoborockMapDataParser._get_bytes(raw, block_data_start, block_data_length)
-                    # only the indexes where value == 1 are in carpet_map
-                    map_data.carpet_map = RoborockMapDataParser._parse_carpet_map(data)
+                    map_data.carpet_map, map_data.additional_parameters["removed_map"] = (
+                        RoborockMapDataParser._parse_submap(data)
+                    )
                 case RoborockBlockType.NO_CARPET_AREAS.value:
                     map_data.no_carpet_areas = RoborockMapDataParser._parse_area(header, data)
                 case _:
@@ -186,6 +194,7 @@ class RoborockMapDataParser(MapDataParser):
                 data=img_data,
                 header=img_header,
                 carpet_map=map_data.carpet_map,
+                removed_map=map_data.additional_parameters.get("removed_map"),
             )
             map_data.image = image
             map_data.rooms = rooms
@@ -219,13 +228,14 @@ class RoborockMapDataParser(MapDataParser):
         data: bytes,
         header: bytes,
         carpet_map: set[int] | None,
+        removed_map: set[int] | None = None,
     ) -> tuple[ImageData, dict[int, Room]]:
         image_size = block_data_length
         image_top = RoborockMapDataParser._get_int32(header, block_header_length - 16)
         image_left = RoborockMapDataParser._get_int32(header, block_header_length - 12)
         image_height = RoborockMapDataParser._get_int32(header, block_header_length - 8)
         image_width = RoborockMapDataParser._get_int32(header, block_header_length - 4)
-        image, rooms_raw = self._image_parser.parse(data, image_width, image_height, carpet_map)
+        image, rooms_raw = self._image_parser.parse(data, image_width, image_height, carpet_map, removed_map)
         if image is None:
             image = self._image_generator.create_empty_map_image()
         rooms = {}
@@ -266,13 +276,19 @@ class RoborockMapDataParser(MapDataParser):
         return room
 
     @staticmethod
-    def _parse_carpet_map(data: bytes) -> set[int]:
-        carpet_map = set()
-
+    def _parse_submap(data: bytes) -> tuple[set[int], set[int]]:
+        carpet_map: set[int] = set()
+        removed_map: set[int] = set()
         for i, v in enumerate(data):
-            if v:
+            if  v == RoborockSubmapType.CARPET.value:
                 carpet_map.add(i)
-        return carpet_map
+            elif v == RoborockSubmapType.REMOVED_BORDER.value:
+                removed_map.add(i)
+            elif v == RoborockSubmapType.REMOVED_AREA.value:
+                removed_map.add(i)
+            elif v != 0:
+                _LOGGER.debug("UNKNOWN SUBMAP TYPE: %d", v)
+        return carpet_map, removed_map
 
     @staticmethod
     def _parse_goto_target(data: bytes) -> Point:

--- a/src/vacuum_map_parser_roborock/map_data_parser.py
+++ b/src/vacuum_map_parser_roborock/map_data_parser.py
@@ -280,13 +280,16 @@ class RoborockMapDataParser(MapDataParser):
         carpet_map: set[int] = set()
         removed_map: set[int] = set()
         for i, v in enumerate(data):
-            if  v == RoborockSubmapType.CARPET.value:
+            if v & RoborockSubmapType.CARPET.value:
                 carpet_map.add(i)
-            elif v == RoborockSubmapType.REMOVED_BORDER.value:
+            if (v & RoborockSubmapType.REMOVED_BORDER.value) or (v & RoborockSubmapType.REMOVED_AREA.value):
                 removed_map.add(i)
-            elif v == RoborockSubmapType.REMOVED_AREA.value:
-                removed_map.add(i)
-            elif v != 0:
+            known_bits = (
+                RoborockSubmapType.CARPET.value
+                | RoborockSubmapType.REMOVED_BORDER.value
+                | RoborockSubmapType.REMOVED_AREA.value
+            )
+            if v & ~known_bits:
                 _LOGGER.debug("UNKNOWN SUBMAP TYPE: %d", v)
         return carpet_map, removed_map
 


### PR DESCRIPTION
Roborock has at least 2 kind of sub map: carpet map and removed map.
Currently this library parse all of them as carpet map. This PR fix it.

## Before
<img width="725" height="1275" alt="image" src="https://github.com/user-attachments/assets/01a55887-40f9-4f86-9641-1fc61c389b6f" />

## After
<img width="513" height="870" alt="image" src="https://github.com/user-attachments/assets/da84f406-4511-4033-abba-4e995ccf6f94" />

## App
<img width="493" height="781" alt="image" src="https://github.com/user-attachments/assets/9e984a13-c5e3-4012-a0f7-bc1606bc802f" />
